### PR TITLE
feat(presets/base.json): set types: []

### DIFF
--- a/presets/base.json
+++ b/presets/base.json
@@ -21,6 +21,7 @@
 		"module": "Preserve",
 		"noUncheckedSideEffectImports": true,
 		"resolveJsonModule": true,
+		"types": [],
 		// Emit
 		// ref: https://www.typescriptlang.org/tsconfig/#Emit_6246
 		"noEmit": true,

--- a/test/__snapshots__/tsc.test.ts.snap
+++ b/test/__snapshots__/tsc.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`tsc --showConfig ./presets/base.json 1`] = `
 "{
@@ -17,6 +17,7 @@ exports[`tsc --showConfig ./presets/base.json 1`] = `
         "module": "preserve",
         "noUncheckedSideEffectImports": true,
         "resolveJsonModule": true,
+        "types": [],
         "noEmit": true,
         "erasableSyntaxOnly": true,
         "verbatimModuleSyntax": true,
@@ -72,6 +73,7 @@ exports[`tsc --showConfig ./presets/bundler/base.json 1`] = `
         "module": "preserve",
         "noUncheckedSideEffectImports": true,
         "resolveJsonModule": true,
+        "types": [],
         "noEmit": true,
         "erasableSyntaxOnly": true,
         "verbatimModuleSyntax": true,
@@ -130,6 +132,7 @@ exports[`tsc --showConfig ./presets/tsc/base.json 1`] = `
         "module": "nodenext",
         "noUncheckedSideEffectImports": true,
         "resolveJsonModule": true,
+        "types": [],
         "noEmit": true,
         "erasableSyntaxOnly": true,
         "verbatimModuleSyntax": true,


### PR DESCRIPTION
follow tsc --init in ts 5.9

BREAKING CHANGE: node_modules/@types is no longer loaded by default
