### PR TITLE
ci: use npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       contents: write # for GitHub Release
       issues: write # for commenting on issues
       pull-requests: write # for commenting on pull requests
-      id-token: write # for npm provenance
+      id-token: write # for npm provenance and trusted publishing
 
     steps:
       - name: Checkout
@@ -57,7 +57,6 @@ jobs:
         run: semantic-release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   actions-timeline:
     needs:


### PR DESCRIPTION
## Summary

- Remove the long-lived `NPM_TOKEN` from the release job.
- Use GitHub Actions OIDC (`id-token: write`) for npm trusted publishing through `semantic-release`.

## Before merging

Configure npm trusted publishing for `@risu729/tsconfigs` on npmjs.com:

- Publisher: GitHub Actions
- Organization or user: `risu729`
- Repository: `tsconfigs`
- Workflow filename: `release.yml`
- Environment name: leave blank, because this workflow does not use a GitHub environment

The workflow file must be `.github/workflows/release.yml`. The package `repository.url` already points at `github.com/risu729/tsconfigs`, which npm checks for provenance/trusted publishing.

Reference: https://docs.npmjs.com/trusted-publishers/

## After the first successful OIDC publish

- Delete the unused `NPM_TOKEN` GitHub Actions secret.
- Revoke the old npm automation token.
- Optional hardening: in npm package settings, set Publishing access to require 2FA and disallow tokens.
