### PR TITLE
chore: remove zizmor GH_TOKEN shim

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -14,5 +14,4 @@ usage = '''
 flag "--lint" help="Run hk check instead of fix"
 '''
 run = "hk {% if usage.lint %}check{% else %}fix{% endif %} --all --no-progress --no-fail-fast"
-env.GH_TOKEN = "{% if env.GITHUB_TOKEN is defined %}{{ env.GITHUB_TOKEN }}{% endif %}"
 description = "Run hk linters and formatters."


### PR DESCRIPTION
## Summary

- Remove the `GH_TOKEN` task-level shim from `tasks.toml`.
- Let zizmor read `GITHUB_TOKEN` directly now that the pinned version supports it.

## Related

- Same cleanup in mikoto: https://github.com/risu729/mikoto/pull/67

## Validation

- `mise run check --lint`