### PR TITLE
ci: trim redundant token env

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,8 +36,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run autofix
         run: mise run check --continue-on-error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run check
         run: mise run check --lint
@@ -64,8 +62,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run tests
         run: mise run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary

- Remove redundant `GITHUB_TOKEN` env entries from `jdx/mise-action` install steps.
- Keep `GITHUB_TOKEN` on the check, autofix, and release execution steps that actually use it.

## Related

- Same cleanup in mikoto: https://github.com/risu729/mikoto/pull/67

## Validation

- `mise run check --lint`

## Summary by Sourcery

CI:
- Remove redundant GITHUB_TOKEN env configuration from jdx/mise-action steps across CI, autofix, and release workflows to rely on default token handling.