### PR TITLE
style: apply pkl 0.32 formatting

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,15 +1,17 @@
 amends "https://raw.githubusercontent.com/risu729/hk-config/v1.0.0/presets.pkl"
+
 import "https://raw.githubusercontent.com/risu729/hk-config/v1.0.0/helpers.pkl"
 
-local picked = helpers.pick(new Listing {
-  "oxlint"
-  "oxfmt"
-  "tsc"
-  "github-actions"
-  "tombi"
-  "yaml"
-  "typos"
-  "hygiene"
-})
+local picked =
+  helpers.pick(new Listing {
+    "oxlint"
+    "oxfmt"
+    "tsc"
+    "github-actions"
+    "tombi"
+    "yaml"
+    "typos"
+    "hygiene"
+  })
 
 hooks = helpers.standardHooks(picked)


### PR DESCRIPTION
## Summary

- apply Pkl 0.32's canonical formatting to `hk.pkl`
- keep the existing hk steps and hooks unchanged

## Validation

- `pkl 0.32.0 format --diff-name-only hk.pkl`
- `pkl 0.32.0 eval hk.pkl`
