### PR TITLE
ci: protect production releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ defaults:
 jobs:
   release:
     name: Release
+    environment: production
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

- associate the release job with the `production` GitHub Environment
- enable deployment protection rules configured for that environment to gate package releases

## Repository configuration

The `production` Environment has been created via the GitHub API. Its deployment branch policy allows only the `main` branch. Required reviewers remain disabled to preserve automated semantic-release publishing.

## Validation

- `mise run check`
- verified the `production` Environment and its `main` branch policy via the GitHub API