### PR TITLE
ci: make CI guard cancellation-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
     needs:
       - lint
       - test
-    # ref: https://github.com/aquaproj/aqua-registry/pull/38449#issuecomment-3038859524
-    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    if: ${{ !cancelled() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions: {}


### PR DESCRIPTION
## Summary

- replace the `always()`-based CI guard with a cancellation-aware predicate
- keep failing the required check when a dependency fails or is cancelled
- let superseded workflow runs stop without scheduling the guard job

## Why

`always()` makes the downstream guard eligible even after the whole workflow is cancelled, so a run superseded by `cancel-in-progress` can still allocate a runner. `!cancelled()` respects whole-run cancellation, while checking `needs.*.result` directly still catches dependency-level cancellation such as a timeout.

The behavior is reproduced in [gha-guard-semantics](https://github.com/risu729/gha-guard-semantics): dependency failure and dependency timeout/cancellation fail the new guard, success and intentional skips skip it, and whole-workflow cancellation cancels it.

## Validation

- repository CI/lint hooks
- live GitHub Actions result matrix in `risu729/gha-guard-semantics`

## Summary by Sourcery

CI:
- Update the CI guard job condition to respect whole-workflow cancellation while preserving failure and dependency-cancellation detection.